### PR TITLE
Ref #100174 - Heading HP

### DIFF
--- a/assets/sass/rennes-hugo/configuration/_colors.sass
+++ b/assets/sass/rennes-hugo/configuration/_colors.sass
@@ -45,6 +45,10 @@ $theme-color-background-alt: map-merge($theme-color-background-alt, ('body[class
 $theme-color-background-accent: map-merge($theme-color-background-accent, ('body[class*="nos-actions"], .page-nos-actions': "#D9FFCC"))
 $theme-color-background-alt: map-merge($theme-color-background-alt, ('body[class*="nos-actions"], .page-nos-actions': "#ECFFE6"))
 
+// "Métropole"
+$theme-color-background-accent: map-merge($theme-color-background-accent, ('body[class*="metropole"]': "#FFE4A8"))
+$theme-color-background-alt: map-merge($theme-color-background-alt, ('body[class*="metropole"]': "#FFE4A8"))
+
 // Add possibility to add custom values
 $custom-theme-color-background-accent: () !default
 $custom-theme-color-background-alt: () !default

--- a/assets/sass/rennes-hugo/design-system/_hero.sass
+++ b/assets/sass/rennes-hugo/design-system/_hero.sass
@@ -1,4 +1,10 @@
 .hero
+  .page-home-metropole &,
+  .page-home-post &
+    padding-bottom: 0
+    margin-bottom: 0
+    background-color: var(--color-background-alt)
+
   .breadcrumb
     margin-top: pxToRem(28)
     @include media-breakpoint-up(desktop)
@@ -13,6 +19,29 @@
     @include media-breakpoint-up(desktop)
       margin-top: pxToRem(32)
 
+    .page__home &
+      align-items: center
+
+    .page-home-metropole &,
+    .page-home-post &
+      margin-top: 0
+      padding-top: 0
+
+      @include media-breakpoint-down(lg)
+        padding-block: $spacing-3
+
+    hgroup.has-lead
+      & > p
+        .page__home &
+          @include media-breakpoint-down(xl)
+            font-size: pxToRem(20)
+
+    figure
+      .page-home-metropole &,
+      .page-home-post &
+        @include media-breakpoint-up(md)
+          width: columns(6)
+
     .hero-text
       display: flex
       flex-direction: column
@@ -25,6 +54,11 @@
 
         @include media-breakpoint-up(desktop)
           margin-bottom: $spacing-4
+
+  h1
+    .page__home &
+      @include media-breakpoint-down(xl)
+        font-size: pxToRem(30)
 
   &--image-portrait, &--image-square
     .content


### PR DESCRIPTION
Ajouter les classes : `home-metropole` pour la page de la métropole et `home-post` pour Ici Rennes depuis le backoffice (pour la gestion de la couleur de fond et du format plus large de l'image)