### PR TITLE
Grille d'organisation : 3 colonnes

### DIFF
--- a/assets/sass/rennes-hugo/blocks/organizations.sass
+++ b/assets/sass/rennes-hugo/blocks/organizations.sass
@@ -29,8 +29,14 @@
         margin-top: $spacing-2
 
 .organizations--grid
+  @include grid(2, md)
+
   @include in-page-with-sidebar
-      @include grid(2, lg)
+    @include grid(2, lg)
+
+  @include in-page-without-sidebar
+    @include grid(3, xl)
+
   @include media-breakpoint-down(sm)
     grid-template-columns: 1fr
 


### PR DESCRIPTION
Légère modification des listes d'organisations en layout grille et sur [l'index des organisations](https://metropole.rennes.fr/organisations)

## Screenshots 

### Pleine largeur

Avant : 

<img width="2048" height="1040" alt="Capture d’écran 2026-04-28 à 14 45 54" src="https://github.com/user-attachments/assets/32b07ec9-c310-4e7e-881f-b10e3ce9c357" />



Après : 

<img width="2048" height="1039" alt="Capture d’écran 2026-04-28 à 14 46 06" src="https://github.com/user-attachments/assets/8cc7e730-33ee-4b98-8677-01174b7f53df" />


### Largeur partielle et écran sous `768px` 


Avant :

<img width="983" height="388" alt="Capture d’écran 2026-04-28 à 14 45 45" src="https://github.com/user-attachments/assets/86be4888-6570-45fa-995d-4330ac792002" />



Après : 

<img width="985" height="495" alt="Capture d’écran 2026-04-28 à 14 45 38" src="https://github.com/user-attachments/assets/340d135b-5477-4243-8e51-53a3f5d3b335" />
