### PR TITLE
Retirer la marge au dessus du `breadcrumb`

### DIFF
--- a/assets/sass/rennes-hugo/design-system/_hero.sass
+++ b/assets/sass/rennes-hugo/design-system/_hero.sass
@@ -4,8 +4,10 @@
       height: $spacing-6
 
     &-nav
-      @include media-breakpoint-down(desktop)
-        padding-top: $spacing-2
+      padding-top: $spacing-2
+
+      @include media-breakpoint-up(desktop)
+        padding-top: $spacing-5
 
   .content
     margin-top: pxToRem(20)

--- a/assets/sass/rennes-hugo/design-system/_hero.sass
+++ b/assets/sass/rennes-hugo/design-system/_hero.sass
@@ -1,7 +1,6 @@
 .hero
   .breadcrumb
     @include media-breakpoint-up(desktop)
-      margin-top: $spacing-5
       height: $spacing-6
 
     &-nav


### PR DESCRIPTION
Cela provoque un espace sous les alertes. Je vous laisse confirmer @malika-hanotte @elisabeth-ecedi, je veux pas faire de bêtise !

<img width="1440" height="665" alt="image" src="https://github.com/user-attachments/assets/6dac2ce0-ebd7-498e-9239-4ac769244987" />
